### PR TITLE
Don't test background-threads on freebsd.

### DIFF
--- a/bb_master_config/master.cfg
+++ b/bb_master_config/master.cfg
@@ -151,13 +151,14 @@ for configuration in configurations:
             workernames=["ubuntu-worker"],
             factory=genFactory("make", configuration)))
     # FreeBSD
-    freebsd_name = "freebsd(" + ", ".join(configuration) + ")"
-    ALL_BUILDER_NAMES.append(freebsd_name)
-    c['builders'].append(
-        util.BuilderConfig(
-            name=freebsd_name,
-            workernames=["freebsd-worker"],
-            factory=genFactory("gmake", configuration)))
+    if "--with-malloc-conf=background_thread:true" not in configuration:
+        freebsd_name = "freebsd(" + ", ".join(configuration) + ")"
+        ALL_BUILDER_NAMES.append(freebsd_name)
+        c['builders'].append(
+            util.BuilderConfig(
+                name=freebsd_name,
+                workernames=["freebsd-worker"],
+                factory=genFactory("gmake", configuration)))
 
 
 ####### SCHEDULERS


### PR DESCRIPTION
These are not supported at boot time, due to fundamental reentrancy scenarios at
play on freebsd.