### PR TITLE
Kill the contributor whitelist.

### DIFF
--- a/bb_master_config/master.cfg
+++ b/bb_master_config/master.cfg
@@ -95,8 +95,6 @@ c['change_source'].append(
         token=MASTER_BB_SECRETS['github_access_token'],
         repository_type='git',
         pollInterval=30,
-        pullrequest_filter=(
-            lambda pr: pr['user']['login'] in GITHUB_TRUSTED_USERS),
         pollAtLaunch=True))
 
 


### PR DESCRIPTION
Nobody's trying to steal our $5 VMs, and even if they did we could wipe and
reset fairly easily.  Meanwhile, this is a constant source of contributor pain.